### PR TITLE
Fix method for removing empty tags

### DIFF
--- a/Content/Scripts/adobedc-html2xhtml.py
+++ b/Content/Scripts/adobedc-html2xhtml.py
@@ -33,10 +33,10 @@ for tag in bod():
 	elif tag.name == "span":
 		tag.unwrap()
 	elif tag.name in ["h1", "h2", "h3", "h4", "div", "ol", "ul", "li", "p"]:
-		if re.search(r'\w', tag.get_text()) or tag.contents[0].name in ["img", "h1", "h2", "h3", "h4", "div", "li", "ol", "ul", "p", "span"]:
-			pass
-		else:
+		if len(tag.text) == 0:
 			tag.decompose()
+		else:
+			pass
 	else:
 		pass
 


### PR DESCRIPTION
Current method causes index out of bounds bc/of `contents[0]`. Need to remove empty tags, ideally nested empty tags as well.
  